### PR TITLE
Replace unmaintained ssmtp with msmtp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
     fail2ban \
+    msmtp \
     nftables \
-    ssmtp \
     whois && \
   echo "**** copy fail2ban confs to /defaults ****" && \
   mkdir -p \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,8 +15,8 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
     fail2ban \
+    msmtp \
     nftables \
-    ssmtp \
     whois && \
   echo "**** copy fail2ban confs to /defaults ****" && \
   mkdir -p \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,8 +15,8 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache --upgrade \
     fail2ban \
+    msmtp \
     nftables \
-    ssmtp \
     whois && \
   echo "**** copy fail2ban confs to /defaults ****" && \
   mkdir -p \

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **15.12.22:** - Replace unmaintained ssmtp with msmtp.
 * **15.12.22:** - Rebase to Alpine 3.17, Add ssmtp and whois packages. Symlink config to allow live reloading.
 * **25.08.22:** - Update README to clarify remote log information.
 * **09.08.22:** - Initial Release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "15.12.22:", desc: "Replace unmaintained ssmtp with msmtp."}
   - { date: "15.12.22:", desc: "Rebase to Alpine 3.17, Add ssmtp and whois packages. Symlink config to allow live reloading."}
   - { date: "25.08.22:", desc: "Update README to clarify remote log information." }
   - { date: "09.08.22:", desc: "Initial Release." }


### PR DESCRIPTION
https://pkgs.alpinelinux.org/package/v3.17/main/x86_64/ssmtp no mention of deprecation, just linking the alpine package since we use the alpine base

https://packages.debian.org/stable/mail/ssmtp alpine package links here

https://wiki.debian.org/sSMTP this page says `Package is currently unmaintained`

Ref: https://github.com/linuxserver/docker-fail2ban/issues/6 https://github.com/linuxserver/docker-fail2ban/issues/9

NOTE:
The contents of the package for [ssmtp](https://pkgs.alpinelinux.org/contents?branch=v3.17&name=ssmtp&arch=x86_64&repo=main) include a replacement for `sendmail` which causes the issue in #9 
The contents of the package for [msmtp](https://pkgs.alpinelinux.org/contents?branch=v3.17&name=msmtp&arch=x86_64&repo=community) do not include a replacement for `sendmail` however it is included in [busybox](https://busybox.net/downloads/BusyBox.html#sendmail).