### PR TITLE
Added iptables-legacy to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     fail2ban \
+    iptables-legacy \
     logrotate \
     msmtp \
     nftables \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,6 +15,7 @@ RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     fail2ban \
+    iptables-legacy \
     logrotate \
     msmtp \
     nftables \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x ] I have read the [contributing](https://github.com/linuxserver/docker-fail2ban/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The recent rebase to Alpine 3.19 broke the functionality on hosts which use iptables such as Unraid. This PR also installs the Alpine package `iptables-legacy` so that users on these systems may still use the container. This PR fixes #25.

## Benefits of this PR and context:
The container is unusable on hosts which only have iptables. With this PR it will remain usable.

## How Has This Been Tested?
Installed a container on two computers, one which is an Unraid system and another an Arch linux system. The Unraid one uses iptables while the Arch one uses nftables. I configured fail2ban to monitor ssh on each, and an entry was added to the tables for ssh as expected. After multiple test unsuccessful attempts it blocked me afterwards. @danielaranki performed a similar test last week and showed his findings in #25.

The user will need to specify in their jail.local file which backend to use (also pointed out by @danielaranki in #25):

```
banaction = iptables-multiport[iptables=iptables-legacy]
```
